### PR TITLE
Fixed mouse coords for big terminals (>=96 columns)

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,8 +90,8 @@ var Mouse = module.exports = (function() {
 					e.shift = !!(modifier & 4);
 					e.meta = !!(modifier & 8);
 					e.ctrl = !!(modifier & 16);
-					e.x = s.charCodeAt(4) - 32;
-					e.y = s.charCodeAt(5) - 32;
+					e.x = d.readUInt8(4) - 32;
+					e.y = d.readUInt8(5) - 32;
 					e.button = null;
 					e.sequence = s;
 					e.buf = Buffer(e.sequence);


### PR DESCRIPTION
For columns >=96 mouse event data has bytes which
cannot be correctly converted to utf8 string.
Result string will have utf8 replacement character
with charcode 65533 and all columns >= 96 will be
incorrectly counted as 65501

Use readUInt8 directly on buffer to get correct
column.

replacement character for nonexistent UTF8 symbol